### PR TITLE
UtilizationAndPower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-#Change Log
+# Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
-## Unreleased]
+## Unreleased
+- added metrics for `utilization.gpu`, `utilization.memory` (in percent)
+- added metric for `power.draw` (in Watt)
 
 ## [0.0.2] - 2015-07-14
 ### Changed

--- a/bin/metrics-nvidia.rb
+++ b/bin/metrics-nvidia.rb
@@ -40,7 +40,7 @@ class EntropyGraphite < Sensu::Plugin::Metric::CLI::Graphite
 
   def run
     metrics = {}
-    keys = ['temperature.gpu', 'fan.speed', 'memory.used', 'memory.total', 'memory.free']
+    keys = ['temperature.gpu', 'fan.speed', 'memory.used', 'memory.total', 'memory.free', 'utilization.memory', 'utilization.gpu', 'power.draw']
     keys.each do |key|
       metrics[key] = `nvidia-smi --query-gpu=#{key} --format=csv,noheader`.match(/\d+\.?\d*/).to_s
     end


### PR DESCRIPTION
read out some more fields that I considered helpful for graphing and storing GPU activity.

Not sure why utilization.gpu was not collected in the first place. Maybe the option is newer than this check.