### PR TITLE
make metrics multi GPU aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-#Change Log
+# Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
-## Unreleased]
+## Unreleased
+### Changed
+- make metrics multi GPU aware
 
 ## [0.0.2] - 2015-07-14
 ### Changed

--- a/bin/metrics-nvidia.rb
+++ b/bin/metrics-nvidia.rb
@@ -39,7 +39,6 @@ class EntropyGraphite < Sensu::Plugin::Metric::CLI::Graphite
          default: "#{Socket.gethostname}.nvidia"
 
   def run
-
     # get the slots for labelling multiple GPUs
     pci_slots = `nvidia-smi --query-gpu=pci.bus --format=csv,noheader`.scan(/^.+$/)
 
@@ -59,7 +58,7 @@ class EntropyGraphite < Sensu::Plugin::Metric::CLI::Graphite
       metrics.each do |key, value|
         output [[config[:scheme], pci_slots[pci_index]].join('.bus'), key].join('.'), value[pci_index], timestamp
       end
-      pci_index = pci_index + 1
+      pci_index += 1
     end
     ok
   end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Collect metrics from more than the first GPU.

#### Known Compatablity Issues

#### Sample output

```plain
slamattack.nvidia.bus0x02.temperature.gpu 44 1484180956
slamattack.nvidia.bus0x02.fan.speed 28 1484180956
slamattack.nvidia.bus0x02.memory.used 0 1484180956
slamattack.nvidia.bus0x02.memory.total 4041 1484180956
slamattack.nvidia.bus0x02.memory.free 4041 1484180956
slamattack.nvidia.bus0x03.temperature.gpu 42 1484180956
slamattack.nvidia.bus0x03.fan.speed 26 1484180956
slamattack.nvidia.bus0x03.memory.used 0 1484180956
slamattack.nvidia.bus0x03.memory.total 4043 1484180956
slamattack.nvidia.bus0x03.memory.free 4043 1484180956
slamattack.nvidia.bus0x83.temperature.gpu 39 1484180956
slamattack.nvidia.bus0x83.fan.speed 26 1484180956
slamattack.nvidia.bus0x83.memory.used 0 1484180956
slamattack.nvidia.bus0x83.memory.total 4043 1484180956
slamattack.nvidia.bus0x83.memory.free 4043 1484180956
slamattack.nvidia.bus0x84.temperature.gpu 42 1484180956
slamattack.nvidia.bus0x84.fan.speed 26 1484180956
slamattack.nvidia.bus0x84.memory.used 0 1484180956
slamattack.nvidia.bus0x84.memory.total 4043 1484180956
slamattack.nvidia.bus0x84.memory.free 4043 1484180956
```

I'm completely open to suggestions if anyone thinks using "bus" is not optimal. 