### PR TITLE
Add GPU utilisation, GPU memory usage and power draw to collected metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-#Change Log
+# Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
-## Unreleased]
+## Unreleased
+- added metrics for `utilization.gpu`, `utilization.memory` (in percent)
+- added metric for `power.draw` (in Watt)
 
 ## [0.0.2] - 2015-07-14
 ### Changed

--- a/bin/metrics-nvidia.rb
+++ b/bin/metrics-nvidia.rb
@@ -40,7 +40,7 @@ class EntropyGraphite < Sensu::Plugin::Metric::CLI::Graphite
 
   def run
     metrics = {}
-    keys = ['temperature.gpu', 'fan.speed', 'memory.used', 'memory.total', 'memory.free']
+    keys = ['temperature.gpu', 'fan.speed', 'memory.used', 'memory.total', 'memory.free', 'utilization.memory', 'utilization.gpu', 'power.draw']
     keys.each do |key|
       metrics[key] = `nvidia-smi --query-gpu=#{key} --format=csv,noheader`.match(/\d+\.?\d*/).to_s
     end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Newer NVIDIA cards offer to read the Utilisation and Memory usage in percent, this PR adds that capability to the metrics.

#### Known Compatablity Issues

None; the check already looks for integers via Regex. If a metric is not available on an older card, nvidia-smi just returns `N/A`.

*Additionally I want to apologize for the sloppy PR that was the first version of this. I wasn't aware the Github Mac GUI didn't respect PR templates.*